### PR TITLE
Meta viewport, CanvasRenderer

### DIFF
--- a/Sketchbots/sw/ui/controller/libs/contrib/gcode/gcode-viewer-mootools.js
+++ b/Sketchbots/sw/ui/controller/libs/contrib/gcode/gcode-viewer-mootools.js
@@ -57,10 +57,20 @@ var GCodeScene = new Class({
 
     _initializeScene: function(element, height, width) {
         // Renderer
-        var renderer = new THREE.WebGLRenderer({
-            clearColor: 0x000000,
-            clearAlpha: 1
-        });
+		if (this._detectWebGL()) {
+			console.log("WebGL");
+			var renderer = new THREE.WebGLRenderer({
+				clearColor: 0x000000,
+				clearAlpha: 1
+			});
+		} else {
+			console.log("Canvas");
+			var renderer = new THREE.CanvasRenderer({
+				clearColor: 0x000000,
+				clearAlpha: 1
+			});
+		}
+
         renderer.setSize(width, height);
         $(renderer.domElement).inject(element);
         renderer.clear();
@@ -342,5 +352,15 @@ var GCodeScene = new Class({
         object.scale.multiplyScalar(scale);
 
         return object;
-    }
+    },
+
+	_detectWebGL: function() {
+		try {
+			var canvas = document.createElement('canvas');
+			return (!! window.WebGLRenderingContext && ( canvas.getContext( 'webgl' ) || canvas.getContext( 'experimental-webgl' ) ));
+		}
+		catch(e) {
+			return false;
+		}
+	}
 });

--- a/Sketchbots/sw/ui/index.html
+++ b/Sketchbots/sw/ui/index.html
@@ -5,6 +5,7 @@
         <!-- -------------- views -------------- -->
             <link rel="stylesheet" type="text/css" href="view/RobotsView.css"></link>
             <script type="application/javascript" src="view/RobotsViewStrings.js"></script>
+			<meta content="initial-scale=1.0" name="viewport">
 
 
         <!-- -------------- controllers and logic -------------- -->


### PR DESCRIPTION
Added meta viewport (#65). I chose this form because it seems to be the most cross-browser friendly. I'm open to debating that.

Instantiated CanvasRenderer where WebGL is unavailable, implemented in a short private function (#70). I left the `console.log()`s in place as they seem to be productive elsewhere in the project. Tested, and functions in the iOS 7 Simulator\* and Android 4.3 / Nexus 4 emulator.

(\* No WebRTC in Safari so taking the actual picture doesn't work; nor, obviously, does the swf fallback.)
